### PR TITLE
Clarify partial confidence definition for different implementation types

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Every pillar score carries a confidence level based on available evidence:
 | Confidence | Meaning |
 |------------|---------|
 | `verified` | Artifacts were present and analyzed. Score reflects evidence. |
-| `partial` | Some artifacts present, some inaccessible (e.g. cloud configs not in repo). |
+| `partial` | Some evidence assessed, meaningful gaps remain. For static implementations: artifacts present but inaccessible (e.g. cloud configs not in repo). For dialogue-driven implementations: some evidence shared but not all. |
 | `self_reported` | No artifacts found. Score based on absence of evidence. |
 
 A `verified` score of 65 is more meaningful than a `self_reported` score of 90. Confidence must be displayed alongside every score.


### PR DESCRIPTION
The current definition assumes static/repo-scanning implementations where artifacts may exist but be inaccessible (e.g. cloud configs). Dialogue-driven implementations (e.g. awaf-skill) assign partial when some evidence was shared but gaps remain. Both are valid uses of partial confidence.