### PR TITLE
Roadmap P0/P1: fill IMPLEMENTATIONS + CONTRIBUTING, FRAMEWORK.md parity + enforced rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,51 @@
 # Contributing to AWAF
 
-RFC process for proposing changes to the specification. Coming soon.
+AWAF is an open specification. It improves through real-world use, and contributions are welcome from anyone building or operating AI agents in production. The bar for changing the specification is deliberately high: changes should reflect demonstrated failure modes from production systems, not hypothetical risks.
+
+## What belongs here
+
+**In scope for this repo:**
+
+- New questions that surface real agent failure modes.
+- Evidence that an existing question is too broad or too narrow.
+- Proposed Tier 2 pillars for failure modes not currently covered.
+- Case studies of agents scored against AWAF.
+- Corrections and clarifications to [FRAMEWORK.md](FRAMEWORK.md).
+
+**Not in scope for this repo:**
+
+- Tooling changes. Open those in [awaf-cli](https://github.com/YogirajA/awaf-cli/issues).
+- Runtime-specific or framework-specific extensions. Open a Discussion first.
+
+To list a tool that implements AWAF, see [IMPLEMENTATIONS.md](IMPLEMENTATIONS.md); that does not go through the RFC process.
+
+## The RFC process
+
+Specification changes go through a lightweight RFC (Request for Comments) so the reasoning is recorded alongside the change.
+
+1. **Raise it.** Open a GitHub Issue (or Discussion) describing the failure mode you want the spec to catch or the problem with an existing question. Include evidence: a real incident, a class of bug, or a pattern you have seen fail in production. Proposals without a demonstrated failure mode will be asked for one.
+2. **Propose it.** If there is appetite, open a PR that edits `FRAMEWORK.md`. The PR description is the RFC and must state:
+   - **The change:** the exact question, criterion, or pillar being added, removed, or reworded.
+   - **The rationale:** the demonstrated failure mode it addresses.
+   - **The version impact:** major or minor (see Versioning below), with a one-line justification.
+   - **Migration notes:** what an existing adopter or implementation must change, if anything.
+3. **Review.** A maintainer and the community discuss on the PR. Expect pushback: the question is always "has this failure mode actually been observed in production?"
+4. **Land it.** On acceptance, the same PR (or a follow-up) updates the version table in [README.md](README.md), bumps the version banner in `FRAMEWORK.md`, and the release is tagged. Implementations then adopt the new version at their own pace and update their listing in `IMPLEMENTATIONS.md`.
+
+## Versioning
+
+AWAF is versioned independently of any tool that implements it.
+
+- **Major version** (for example v1 to v2): breaking changes to pillar definitions, scoring weights, tier assignments, or question sets. Existing scores are not comparable across a major bump.
+- **Minor version** (for example v1.3 to v1.4): additive changes such as new questions, new advisory signals, or clarifications that do not change how existing answers score.
+
+Every change to the specification content must move the version. Prose fixes that do not change meaning (typos, formatting) do not.
+
+## Style
+
+- Follow the writing style in [CLAUDE.md](CLAUDE.md): no em dashes in prose sentences.
+- Keep questions concrete and answerable from evidence. A good question can be answered "yes / partially / no" by looking at code, configuration, or operational artifacts.
+
+## License
+
+By contributing you agree that your contribution is licensed under Apache 2.0, the same license as the specification. See [LICENSE](LICENSE).

--- a/FRAMEWORK.md
+++ b/FRAMEWORK.md
@@ -2,13 +2,15 @@
 
 Full pillar definitions for the AI Agents Well-Architected Framework.
 
+**Specification version: v1.4.** See the [version history](README.md#specification-versioning) for what each version changed.
+
 ---
 
 ## Foundation (Prerequisite)
 
 **Vertical Slice & Autonomy**: Agents must own their domain end-to-end with independent tools, context, and data. A vertically sliced agent owns its domain end-to-end: its tools, its context, its data. Tools must be single-purpose with explicitly described capabilities. Inter-agent data contracts must be typed rather than free-form text.
 
-**Pattern justification (advisory)**: The agent pattern is appropriate for complex, multi-step, adaptive tasks with real-time decisions. Deterministic workflows, simple Q&A, or single-shot tool calls are better served by simpler patterns (workflow, augmented LLM, or prompt). If a simpler pattern would suffice, this is surfaced as a Caution finding, not a score penalty. The agent may already be built; this is retrospective guidance. The assessor should name the observed pattern (Scratchpad, Chain of Thought, ReAct, Plan & Execute, Reflexion, Self-Consistency, Tool-Augmented Scratchpad, or Memory-Augmented Generation) and the simpler alternative when raising this Caution.
+**Pattern justification (advisory)**: The agent pattern is appropriate for complex, multi-step, adaptive tasks with real-time decisions. Deterministic workflows, simple Q&A, or single-shot tool calls are better served by simpler patterns (workflow, augmented LLM, or prompt). If a simpler pattern would suffice, this is surfaced as a Medium finding, not a score penalty. The agent may already be built; this is retrospective guidance. The assessor should name the observed pattern (Scratchpad, Chain of Thought, ReAct, Plan & Execute, Reflexion, Self-Consistency, Tool-Augmented Scratchpad, or Memory-Augmented Generation) and the simpler alternative when raising this Medium finding.
 
 ---
 
@@ -60,9 +62,23 @@ Manages agent perception of reality. Prevents stale context from corrupting reas
 
 ## Scoring Methodology
 
-Each pillar uses a mechanical risk tally. Every criterion is assigned H (3 pts), M (2 pts), or L (1 pt) and marked pass or fail with a one-line evidence citation. The pillar score equals `round(sum_passed_pts / sum_all_pts × 100)`.
+Each pillar uses a mechanical risk tally. Every criterion is assigned H (3 pts), M (2 pts), or L (1 pt) and marked pass or fail with a one-line evidence citation. The pillar score equals `round(sum_passed_pts / sum_all_pts × 100)`. Answering "none of these apply" to a pillar's criteria triggers an automatic High Risk flag and caps that pillar's score at 30, regardless of the tally.
 
 The overall score is a weighted average: `sum(score × weight) / sum(weights)`. Tier 2 pillars carry 1.5× weight. Skipped or not-applicable pillars are excluded from both numerator and denominator.
+
+**Foundation gate.** Foundation is a prerequisite, not one pillar among ten. If Foundation scores below 40, the agent fails and the remaining pillars are not scored: an agent that cannot run independently has a structural problem that higher-level scores would only obscure.
+
+### Confidence Levels
+
+Every pillar score carries a confidence level based on the evidence available:
+
+| Confidence | Meaning |
+|---|---|
+| `verified` | Artifacts were present and analyzed. The score reflects evidence. |
+| `partial` | Some evidence was assessed, but meaningful gaps remain (for example, cloud configs not in the repo, or a dialogue-driven assessment where not all evidence was shared). |
+| `self_reported` | No artifacts were found. The score reflects the absence of evidence. |
+
+A `verified` score of 65 is more meaningful than a `self_reported` score of 90. Confidence must be displayed alongside every score.
 
 ### Readiness Bands
 

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -1,3 +1,52 @@
 # AWAF Implementations
 
-Community implementations of the AWAF specification. Open a PR to add yours.
+Tools that implement the [AWAF specification](FRAMEWORK.md). To add yours, open a PR using the template at the bottom of this page.
+
+An AWAF-compatible implementation should:
+
+- Score all 10 pillars across the 3 tiers.
+- Apply the tier weights (Tier 2 pillars count 1.5x; Tier 0 and Tier 1 count 1.0x).
+- Enforce the Foundation gate: if Foundation scores below 40, do not score the other pillars and report a fail.
+- Report readiness using the standard bands (Production Ready / Near Ready / Needs Work / High Risk / Not Ready) at the 85 / 70 / 50 / 25 / 0 boundaries.
+- Display a confidence level (`verified`, `partial`, `self_reported`) alongside every score.
+- State which AWAF version it targets.
+
+---
+
+## Reference implementations
+
+Maintained by the AWAF authors.
+
+### awaf-cli
+
+- **Repo:** https://github.com/YogirajA/awaf-cli
+- **Install:** `pip install awaf`
+- **AWAF version:** v1.4
+- **Type:** Command-line tool and CI check (Python)
+- **What it does:** Runs all 10 pillars against a repository through an LLM provider of your choice (Anthropic, OpenAI, Azure OpenAI, Google, or LiteLLM). Produces a scored report with cited `file:line` findings, a self-contained HTML report, and a code-graph evidence view. Stores score history in SQLite for regression detection, and gates CI by exit code.
+
+### awaf-skill
+
+- **Repo:** https://github.com/YogirajA/awaf-skill
+- **Install:** Claude Code plugin via the `awaf-marketplace` (`/plugin`)
+- **AWAF version:** v1.4
+- **Type:** Claude Code skill / plugin
+- **What it does:** Runs an interactive AWAF assessment inside Claude Code, from code, cloud configs, eval reports, or a verbal description of the system. Produces the same scored report and HTML output as the CLI, with `file:line` findings.
+
+---
+
+## Community implementations
+
+None yet. Yours could be the first. Open a PR adding a section below using this template:
+
+```markdown
+### <name>
+
+- **Repo:** <url>
+- **Install:** <how to install or use it>
+- **AWAF version:** <v1.4 | ...>
+- **Type:** <CLI | library | service | IDE plugin | ...>
+- **What it does:** <one or two sentences: what it scores, from what evidence, and how it reports.>
+```
+
+Implementations are listed as a convenience to the community. Listing does not imply certification or endorsement by the AWAF authors. See [CONTRIBUTING.md](CONTRIBUTING.md) for how spec changes are proposed, and the [LICENSE](LICENSE) for use of the AWAF name.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The specification defines:
 - What risk levels map to what scores
 - What "Production Ready" vs "High Risk" means, precisely
 
-The reference implementation is [awaf-cli](https://github.com/YogirajA/awaf-cli): a CLI that scores your agent and gates CI by exit code.
+The reference implementation is [awaf-cli](https://github.com/YogirajA/awaf-cli): a CLI and GitHub Action that scores your agent in CI.
 
 ---
 
@@ -155,7 +155,7 @@ When citing AWAF, always reference the version: _"This agent is designed to AWAF
 
 ### With the reference implementation
 
-[awaf-cli](https://github.com/YogirajA/awaf-cli) implements AWAF v1.4 as a CLI tool with CI integration. Wire it into a pull-request check to produce a scored report with specific cited findings.
+[awaf-cli](https://github.com/YogirajA/awaf-cli) implements AWAF v1.4 as a CLI tool and [GitHub Action](https://github.com/YogirajA/awaf-action). Wire it into a scheduled or pull-request check to produce a scored report with specific cited findings.
 
 ```bash
 pip install awaf
@@ -224,7 +224,7 @@ The AWAF name and logo are trademarks of Yogiraj Aradhye. Use of the specificati
 
 ## Related
 
-- [awaf-cli](https://github.com/YogirajA/awaf-cli): Reference implementation with CLI, CI integration, and score history
+- [awaf-cli](https://github.com/YogirajA/awaf-cli): Reference implementation with CLI, GitHub Action, and score history
 - [FRAMEWORK.md](FRAMEWORK.md): Complete pillar definitions and scoring questions
 - [IMPLEMENTATIONS.md](IMPLEMENTATIONS.md): Community implementations of the specification
 - [Are We Building AI Agents Like We Built Microservices?](https://aradhye.com/ai-agents-well-architected-framework/): The post that introduced AWAF

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The specification defines:
 - What risk levels map to what scores
 - What "Production Ready" vs "High Risk" means, precisely
 
-The reference implementation is [awaf-cli](https://github.com/YogirajA/awaf-cli): a CLI and GitHub Action that scores your agent automatically on every commit.
+The reference implementation is [awaf-cli](https://github.com/YogirajA/awaf-cli): a CLI that scores your agent and gates CI by exit code.
 
 ---
 
@@ -155,7 +155,7 @@ When citing AWAF, always reference the version: _"This agent is designed to AWAF
 
 ### With the reference implementation
 
-[awaf-cli](https://github.com/YogirajA/awaf-cli) implements AWAF v1.4 as a CLI tool and GitHub Action. It runs on every PR that touches agent code and produces a scored report with specific cited findings.
+[awaf-cli](https://github.com/YogirajA/awaf-cli) implements AWAF v1.4 as a CLI tool with CI integration. Wire it into a pull-request check to produce a scored report with specific cited findings.
 
 ```bash
 pip install awaf
@@ -224,7 +224,7 @@ The AWAF name and logo are trademarks of Yogiraj Aradhye. Use of the specificati
 
 ## Related
 
-- [awaf-cli](https://github.com/YogirajA/awaf-cli): Reference implementation with CLI, GitHub Action, and score history
+- [awaf-cli](https://github.com/YogirajA/awaf-cli): Reference implementation with CLI, CI integration, and score history
 - [FRAMEWORK.md](FRAMEWORK.md): Complete pillar definitions and scoring questions
 - [IMPLEMENTATIONS.md](IMPLEMENTATIONS.md): Community implementations of the specification
 - [Are We Building AI Agents Like We Built Microservices?](https://aradhye.com/ai-agents-well-architected-framework/): The post that introduced AWAF


### PR DESCRIPTION
Addresses the spec-repo P0/P1 items from the 2026-07-13 review.

- **P0**: `IMPLEMENTATIONS.md` (which listed nothing) now lists awaf-cli and awaf-skill with a compatibility checklist and an "add yours" template; `CONTRIBUTING.md` (a "coming soon" stub) now documents the RFC process, scope, and versioning that the README already promised.
- **P1**: `FRAMEWORK.md` renames the pattern-advisory severity `Caution` to `Medium` (the last three-way parity drift; the CLI and skill already used Medium), adds a `v1.4` version stamp, and documents three rules it enforces but had omitted: the Foundation < 40 fail gate, the "none apply, so High Risk and cap the pillar at 30" rule, and the verified/partial/self_reported confidence levels.
- README now references the real `YogirajA/awaf-action` GitHub Action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)